### PR TITLE
Add native modules config for cross platform and correct node-gyp path usage.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,88 @@
+# Native Module Configuration
+
+This configuration file allows you to customize how native modules are rebuilt in your project without modifying any JavaScript code.
+
+## Platform Requirements
+
+### Windows:
+- **Visual Studio 2022** (with C++ desktop development workload)
+- **Windows SDK** (included with Visual Studio)
+- **node-gyp** (installed globally via npm)
+
+### macOS:
+- **Xcode Command Line Tools** (`xcode-select --install`)
+- **node-gyp** (installed globally via npm)
+
+### Linux:
+- **GCC/G++** (version supporting C++20)
+- **Python** (for node-gyp)
+- **node-gyp** (installed globally via npm)
+
+## Options
+
+### Windows-specific Options
+- `visualStudioVersion` - Specify which Visual Studio version to use (e.g., "2019", "2022")
+- `nodeGypPath` - Custom path to node-gyp binary (leave empty to use default)
+  - On Windows, this should point to the `.cmd` file (e.g., `C:\\Path\\To\\node-gyp.cmd`)
+
+### Mac-specific Options
+- `nodeGypPath` - Custom path to node-gyp binary (e.g., "/opt/homebrew/bin/node-gyp")
+
+### Linux-specific Options
+- `nodeGypPath` - Custom path to node-gyp binary
+
+> Note: Visual Studio requirements are Windows-only. Other platforms use their native toolchains.
+
+### General Options
+- `cxxStandard` - C++ standard to use (e.g., "c++20", "c++17")
+
+## Example Configuration
+
+```json
+{
+  "windows": {
+    "visualStudioVersion": "2022",
+    "nodeGypPath": "C:\\Path\\To\\node-gyp.cmd"
+  },
+  "mac": {
+    "nodeGypPath": "/opt/homebrew/bin/node-gyp"
+  },
+  "linux": {
+    "nodeGypPath": "/usr/local/bin/node-gyp"
+  },
+  "general": {
+    "cxxStandard": "c++20"
+  }
+}
+```
+
+## Priority Order
+
+The system checks for configuration values in the following order (highest to lowest priority):
+
+1. Environment variables (e.g., `NPM_CONFIG_MSVS_VERSION`, `NODE_GYP_PATH`)
+2. This configuration file (`config/native-modules.json`)
+3. Values in `.npmrc` file
+4. Default values
+
+This means you can temporarily override settings using environment variables without changing the configuration files.
+
+## Notes
+
+### Recommended Configuration Approach
+
+- **Keep .npmrc for:**
+    - Standard npm configurations used by npm/node-gyp
+    - Global settings not specific to any platform
+    - Backward compatibility with existing tools
+
+- **Use config/native-modules.json for:**
+    - Platform-specific settings (like Visual Studio version)
+    - Node-gyp path customization
+    - Settings that vary by operating system
+
+### For Your Users
+
+It is recommended to direct users to modify the native-modules.json file when they need to change Visual Studio version or node-gyp path. The accompanying README provides clear guidance on available options and examples of proper configuration.
+
+This approach gives you the best of both worlds - standard npm configuration plus an improved user experience for the platform-specific settings that are critical for cross-platform compatibility.

--- a/config/UserInstructions.md
+++ b/config/UserInstructions.md
@@ -1,0 +1,123 @@
+# Node-Gyp Setup Instructions
+
+## Windows Setup
+
+### 1. Install Build Tools (Choose One Option)
+
+**Option A: Visual Studio (Recommended)**
+- Download from [Visual Studio website](https://visualstudio.microsoft.com/)
+- Select "Desktop development with C++" workload
+- Includes full IDE and all necessary components
+
+**Option B: Build Tools Only (Lighter Install)**
+- Download [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+- Select these workloads:
+  - "C++ build tools"
+  - "Windows 10/11 SDK"
+  - "MSVC v143 - VS 2022 C++ x64/x86 build tools"
+
+Both options provide the required compilers and tools. Visual Studio provides a full development environment, while Build Tools are sufficient for compilation.
+
+### 2. Install Node-Gyp Globally
+```cmd
+npm install -g node-gyp
+```
+
+### 3. Find Node-Gyp Path
+Choose one method:
+
+**Command Prompt:**
+```cmd
+where node-gyp
+
+# The path will show something like:
+C:\Users\YourUsername\AppData\Roaming\npm\node-gyp.cmd
+```
+
+**PowerShell:**
+```powershell
+(Get-Command node-gyp).Path
+
+# The path will show something like:
+C:\Users\YourUsername\AppData\Roaming\npm\node-gyp.cmd
+```
+
+### 4. Update Configuration
+Copy the path to `config/native-modules.json`:
+```json
+{
+  "windows": {
+    "visualStudioVersion": "2022",
+    # Ensure to replace with \\
+    "nodeGypPath": "C:\\Path\\To\\node-gyp.cmd"
+  }
+}
+```
+
+---
+
+## macOS Setup
+
+### 1. Install Xcode Command Line Tools
+```bash
+xcode-select --install
+```
+
+### 2. Install Node-Gyp Globally
+```bash
+npm install -g node-gyp
+```
+
+### 3. Find Node-Gyp Path
+```bash
+which node-gyp
+
+# The path will show something like:
+/usr/local/bin/node-gyp
+```
+
+### 4. Update Configuration
+```json
+{
+  "mac": {
+    "nodeGypPath": "/usr/local/bin/node-gyp"
+  }
+}
+```
+
+---
+
+## Linux Setup
+
+### 1. Install Build Tools
+```bash
+sudo apt-get update
+sudo apt-get install build-essential python3
+```
+
+### 2. Install Node-Gyp Globally
+```bash
+npm install -g node-gyp
+```
+
+### 3. Find Node-Gyp Path
+```bash
+which node-gyp
+
+# The path will show something like:
+/usr/bin/node-gyp
+```
+
+### 4. Update Configuration
+```json
+{
+  "linux": {
+    "nodeGypPath": "/usr/bin/node-gyp"
+  }
+}
+```
+
+## Verification
+After configuration, run:
+```bash
+npm run rebuild-native-modules

--- a/config/native-modules.json
+++ b/config/native-modules.json
@@ -1,0 +1,15 @@
+{
+  "windows": {
+    "visualStudioVersion": "",
+    "nodeGypPath": ""
+  },
+  "mac": {
+    "nodeGypPath": ""
+  },
+  "linux": {
+    "nodeGypPath": ""
+  },
+  "general": {
+    "cxxStandard": "c++20"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contextcraft",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contextcraft",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/rebuild-native-modules.js
+++ b/scripts/rebuild-native-modules.js
@@ -24,11 +24,202 @@ const nativeModules = [
 ];
 
 /**
+ * Reads configuration from multiple sources with priority:
+ * 1. Environment variables (highest priority)
+ * 2. User config file (config/native-modules.json)
+ * 3. .npmrc file
+ * 4. Default values (lowest priority)
+ * 
+ * @returns {Object} Configuration object with all settings
+ */
+function getConfiguration() {
+  // Start with default configuration
+  const config = {
+    visualStudioVersion: '2019',
+    nodeGypPath: '',
+    cxxStandard: 'c++20'
+  };
+  
+  // Read from .npmrc file (legacy support)
+  const npmrcConfig = readNpmrcFile();
+  if (npmrcConfig['npm_config_msvs_version']) {
+    config.visualStudioVersion = npmrcConfig['npm_config_msvs_version'];
+  }
+  if (npmrcConfig['node-gyp-binary-path']) {
+    config.nodeGypPath = npmrcConfig['node-gyp-binary-path'];
+  }
+  if (npmrcConfig['npm_config_cxx_std']) {
+    config.cxxStandard = npmrcConfig['npm_config_cxx_std'];
+  }
+  
+  // Read from user config file (higher priority)
+  const userConfig = readUserConfigFile();
+  if (userConfig) {
+    // Platform-specific configurations
+    const platformConfig = isWin ? userConfig.windows : 
+                          isMac ? userConfig.mac : 
+                          isLinux ? userConfig.linux : null;
+    
+    if (platformConfig) {
+      if (isWin && platformConfig.visualStudioVersion) {
+        config.visualStudioVersion = platformConfig.visualStudioVersion;
+      }
+      if (platformConfig.nodeGypPath) {
+        config.nodeGypPath = platformConfig.nodeGypPath;
+      }
+    }
+    
+    // General configurations
+    if (userConfig.general && userConfig.general.cxxStandard) {
+      config.cxxStandard = userConfig.general.cxxStandard;
+    }
+  }
+  
+  // Environment variables have highest priority
+  if (process.env.NPM_CONFIG_MSVS_VERSION) {
+    config.visualStudioVersion = process.env.NPM_CONFIG_MSVS_VERSION;
+  }
+  if (process.env.NODE_GYP_PATH) {
+    config.nodeGypPath = process.env.NODE_GYP_PATH;
+  }
+  if (process.env.NPM_CONFIG_CXX_STD) {
+    config.cxxStandard = process.env.NPM_CONFIG_CXX_STD;
+  }
+  
+  // Handle Windows-specific node-gyp path with .cmd extension
+  if (isWin && config.nodeGypPath && !config.nodeGypPath.endsWith('.cmd')) {
+    // Check if we need to add .cmd extension for Windows
+    const cmdPath = `${config.nodeGypPath}.cmd`
+    if (fs.existsSync(cmdPath)) {
+      config.nodeGypPath = cmdPath;
+      console.log(`ℹ️ Detected Windows environment, using ${cmdPath}`);
+    }
+  }
+  
+  return config;
+}
+
+/**
+ * Reads and parses the user configuration file
+ * @returns {Object|null} User configuration object or null if not found
+ */
+function readUserConfigFile() {
+  const configPath = path.join(process.cwd(), 'config', 'native-modules.json');
+  
+  if (fs.existsSync(configPath)) {
+    try {
+      const fileContent = fs.readFileSync(configPath, 'utf8');
+      const config = JSON.parse(fileContent);
+      console.log('📝 Loaded configuration from config/native-modules.json');
+      return config;
+    } catch (err) {
+      console.warn(`⚠️ Error reading configuration file: ${err.message}`);
+    }
+  } else {
+    console.log('ℹ️ No configuration file found at config/native-modules.json');
+  }
+  
+  return null;
+}
+
+/**
+ * Reads and parses the .npmrc file to extract configuration values
+ * @returns {Object} Configuration object with values from .npmrc
+ */
+function readNpmrcFile() {
+  const config = {};
+  const npmrcPath = path.join(process.cwd(), '.npmrc');
+  
+  if (fs.existsSync(npmrcPath)) {
+    try {
+      const fileContent = fs.readFileSync(npmrcPath, 'utf8');
+      const lines = fileContent.split('\n');
+      
+      for (const line of lines) {
+        // Skip empty lines and comments
+        if (!line.trim() || line.startsWith('#')) continue;
+        
+        const [key, value] = line.split('=').map(part => part.trim());
+        if (key && value) {
+          config[key] = value;
+        }
+      }
+      
+      console.log('📝 Loaded configuration from .npmrc file');
+    } catch (err) {
+      console.warn(`⚠️ Error reading .npmrc file: ${err.message}`);
+    }
+  } else {
+    console.log('ℹ️ No .npmrc file found, using default configurations');
+  }
+  
+  return config;
+}
+
+/**
  * Rebuilds native modules with proper C++20 support
  */
+/**
+ * Patches binding.gyp files to ensure C++20 standard is used
+ */
+function patchBindingGypFiles() {
+  console.log('🔧 Patching binding.gyp files for C++20 support...');
+  
+  const modulesDir = path.join(process.cwd(), 'node_modules');
+  
+  // List of modules that need C++20
+  const modulesToPatch = [
+    'tree-sitter',
+    'tree-sitter-javascript',
+    'tree-sitter-typescript',
+    'tree-sitter-python',
+    'tree-sitter-css',
+    'tree-sitter-html'
+  ];
+
+  modulesToPatch.forEach(module => {
+    const bindingGypPath = path.join(modulesDir, module, 'binding.gyp');
+    if (fs.existsSync(bindingGypPath)) {
+      try {
+        let content = fs.readFileSync(bindingGypPath, 'utf8');
+        const originalContent = content;
+        
+        // Replace all C++17 references with C++20
+        content = content
+          .replace(/"-std=c\+\+17"/g, '"-std=c++20"')
+          .replace(/"CLANG_CXX_LANGUAGE_STANDARD": "c\+\+17"/g, '"CLANG_CXX_LANGUAGE_STANDARD": "c++20"')
+          .replace(/"\/std:c\+\+17"/g, '"/std:c++20"');
+        
+        if (content !== originalContent) {
+          fs.writeFileSync(bindingGypPath, content);
+          console.log(`   ✔ Patched ${module}/binding.gyp`);
+        }
+      } catch (err) {
+        console.warn(`   ⚠️ Could not patch ${module}/binding.gyp: ${err.message}`);
+      }
+    }
+  });
+}
+
 async function main() {
   try {
-    console.log('🔄 Rebuilding native modules with C++20 support...');
+    console.log('🔄 Rebuilding native modules with platform-specific configurations...');
+    
+    // Patch binding.gyp files first
+    patchBindingGypFiles();
+    
+    // Get unified configuration from all sources
+    const config = getConfiguration();
+    
+    // Log the final configuration being used
+    console.log('📋 Using configuration:');
+    if (isWin) {
+      console.log(`   - Visual Studio Version: ${config.visualStudioVersion}`);
+    }
+    console.log(`   - C++ Standard: ${config.cxxStandard}`);
+    if (config.nodeGypPath) {
+      console.log(`   - Node-gyp Path: ${config.nodeGypPath}`);
+    }
     
     // Create appropriate compiler flags based on platform
     let env = { ...process.env };
@@ -37,31 +228,46 @@ async function main() {
       // macOS: Use clang with C++20 flags
       env = {
         ...env,
-        npm_config_cxx_std: 'c++20',
-        CXXFLAGS: '-std=c++20',
-        CXX_FLAGS: '-std=c++20',
+        npm_config_cxx_std: config.cxxStandard,
+        CXXFLAGS: `-std=${config.cxxStandard}`,
+        CXX_FLAGS: `-std=${config.cxxStandard}`,
         CC: 'clang',
         CXX: 'clang++'
       };
-      console.log('🍎 Using macOS optimized settings with clang and C++20');
+      
+      if (config.nodeGypPath) {
+        env.npm_config_node_gyp = config.nodeGypPath;
+      }
+      
+      console.log('🍎 Using macOS optimized settings with clang');
     } else if (isWin) {
       // Windows: Use MSVC with C++20 flags
       env = {
         ...env,
-        npm_config_cxx_std: 'c++20',
-        npm_config_msvs_version: '2019',
+        npm_config_cxx_std: config.cxxStandard,
+        npm_config_msvs_version: config.visualStudioVersion,
         npm_config_platform: 'win32'
       };
-      console.log('🪟 Using Windows optimized settings with MSVC and C++20');
+      
+      if (config.nodeGypPath) {
+        env.npm_config_node_gyp = config.nodeGypPath;
+      }
+      
+      console.log(`🪟 Using Windows optimized settings with MSVC ${config.visualStudioVersion}`);
     } else {
       // Linux: Use GCC with C++20 flags
       env = {
         ...env,
-        npm_config_cxx_std: 'c++20',
-        CXXFLAGS: '-std=c++20',
-        CXX_FLAGS: '-std=c++20',
+        npm_config_cxx_std: config.cxxStandard,
+        CXXFLAGS: `-std=${config.cxxStandard}`,
+        CXX_FLAGS: `-std=${config.cxxStandard}`,
       };
-      console.log('🐧 Using Linux optimized settings with GCC and C++20');
+      
+      if (config.nodeGypPath) {
+        env.npm_config_node_gyp = config.nodeGypPath;
+      }
+      
+      console.log('🐧 Using Linux optimized settings with GCC');
     }
 
     // Use electron-rebuild to rebuild native modules
@@ -98,4 +304,4 @@ async function main() {
 }
 
 // Run the main function
-main(); 
+main();


### PR DESCRIPTION
## Fix issues with npmrc to override modules to c++20

Just a simple fix where user can now add custom node-gyp path (All OS) and their Visual Studio version (Windows):
For example:
```json
{
  "windows": {
    "visualStudioVersion": "2022",
    "nodeGypPath": "C:\\Users\\username\\AppData\\Roaming\\npm\\node-gyp.CMD"
  },
  "mac": {
    "nodeGypPath": "/usr/local/bin/node-gyp"
  },
  "linux": {
    "nodeGypPath": "/usr/bin/node-gyp"
  },
  "general": {
    "cxxStandard": "c++20"
  }
}
```

Added user instructions which you can later add to `README.md`.
This just give some instructions on how to setup the path and etc. [UserInstructions.md](/config/UserInstructions.md)

This way user can now properly run `npm run rebuild-native-modules` according to their platform.
And the correct path where they installed `node-gyp`.

**Note that the original `.npmrc` can still be used for (Mac OS) to ensure legacy support.**