### PR TITLE
fix: add explicit status-check job to workflow to fix 'waiting for st…

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -84,3 +84,17 @@ jobs:
         run: npm run test-build:linux
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+  status-check:
+    name: PR Status Check
+    runs-on: ubuntu-latest
+    needs: [validate, test-build]
+    if: always()
+    steps:
+      - name: Check build matrix status
+        if: needs.validate.result == 'success' && needs.test-build.result == 'success'
+        run: exit 0
+      
+      - name: Build matrix failed
+        if: needs.validate.result != 'success' || needs.test-build.result != 'success'
+        run: exit 1 


### PR DESCRIPTION
- Root cause: The GitHub workflow wasn't explicitly reporting a final status check for the workflow itself.
- Solution: Added a dedicated status-check job